### PR TITLE
Add HyperGrok, a seven-agent Hyperliquid trading desk

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ which is which rather than blurring them together, and empty subsections stay la
 
 - [grok-bot-super](https://github.com/AgentMindCloud/grok-bot-super) by [AgentMindCloud](https://github.com/AgentMindCloud) — community skill library (daily standup, email triage, meeting-to-actions, research brief, weekly review, X-thread builder). **[beta]**
 - [grokbot-imessage-skill](https://github.com/jeffhuber/grokbot-imessage-skill) by [jeffhuber](https://github.com/jeffhuber) — read, triage, search and send iMessages on macOS via a local, privacy-first launchd helper (no cloud sync). **[beta]**
+- [HyperGrok](https://github.com/galleonlabs/hypergrok-trading-desk) by [galleonlabs](https://github.com/galleonlabs) — seven-agent Hyperliquid trading desk for Grok Bot: research, size, execute, review. **[beta]**
 
 ### Grok Bot plugins and MCP servers
 


### PR DESCRIPTION
## What kind of change is this?

- [x] New catalog entry
- [ ] Fix a broken/outdated entry
- [ ] Other (README, CONTRIBUTING, infra, etc.)

## Checklist (for new entries)

- [x] The linked repo resolves and is not empty/archived.
- [x] It's genuinely about Grok Bot (xAI + Cursor's cloud-computer product), not Grok Build or an unrelated same-named bot.
- [x] It's not already listed anywhere in this README.
- [x] The entry follows the exact format: `- [name](repo-url) by [author](author-url) — description. **[tag]**`
- [x] It's placed alphabetically within the correct category.

## Anything else maintainers should know?

HyperGrok is a Grok Bot desk: seven Bots plus portable skills, wired to Hyperliquid. Tagged **[beta]** because the product is new; the repo is not a stub. Setup path is SETUP.md.
