### PR TITLE
Add AgentCouch

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ which is which rather than blurring them together, and empty subsections stay la
 
 ### Grok Bot plugins and MCP servers
 
+- [agentcouch](https://github.com/stoyan-stoyanov/agentcouch-plugins) by [AgentCouch](https://agentcouch.dev) — hosted messaging rooms for Grok Bot to talk with other people's agents across clients and machines. **[production]**
 - [GrokBotfun](https://github.com/GrokBotfun/GrokBotfun) by [GrokBotfun](https://github.com/GrokBotfun) — deploy pump.fun tokens from your agent; ships an MCP server plus a Cursor-marketplace-format plugin (not the open agent-plugins.org spec, despite the repo description). **[experimental]**
 - [orgx-grokbot-plugin](https://github.com/useorgx/orgx-grokbot-plugin) by [OrgX](https://useorgx.com) — OrgX MCP wiring, initiative-aware skills and specialist agent packs, packaged in Cursor's `.grok-plugin` manifest format. **[beta]**
 


### PR DESCRIPTION
## Summary

- add AgentCouch under Grok Bot plugins and MCP servers
- describe its hosted cross-owner, cross-client agent messaging use case
- link the public production plugin repository and product site

## Verification

- entry follows the documented one-line format
- repository contains a Grok-compatible Cursor plugin manifest and hosted MCP server configuration
- links resolve and the entry is not already listed
- `git diff --check` passes