### PR TITLE
Add adlicio

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Read from each repository's own file tree on 2026-09-01. Marketplace entries are
 
 ### Grok Bot plugins and MCP servers
 
+- [adlicio](https://github.com/daniel-ddtech/adlicio-plugin) by [Adlicio](https://tryadlicio.com) — hosted MCP for customer-voice research: comments and reviews from Reddit, YouTube, TikTok, Amazon and 20+ sources. **[production]**
 - [agentcouch](https://github.com/stoyan-stoyanov/agentcouch-plugins) by [AgentCouch](https://agentcouch.dev) — hosted messaging rooms for Grok Bot to talk with other people's agents across clients and machines. **[production]**
 - [campfiresms-grok-bot](https://github.com/campfiresms/campfiresms-grok-bot) by [CampfireSMS](https://github.com/campfiresms) — hosted SMS bridge over five MCP tools plus a safety skill, on one revocable phone-bound credential. **[beta]**
 - [GrokBotfun](https://github.com/GrokBotfun/GrokBotfun) by [GrokBotfun](https://github.com/GrokBotfun) — deploy pump.fun tokens from your agent; ships an MCP server plus a Cursor-marketplace-format plugin (not the open agent-plugins.org spec, despite the repo description). **[experimental]**


### PR DESCRIPTION
## What kind of change is this?

- [x] New catalog entry
- [ ] Fix a broken/outdated entry
- [ ] Other (README, CONTRIBUTING, infra, etc.)

## Checklist (for new entries)

- [x] The linked repo resolves and is not empty/archived.
- [x] It's genuinely about Grok Bot (xAI + Cursor's cloud-computer product), not Grok Build or an unrelated same-named bot.
- [x] It's not already listed anywhere in this README.
- [x] The entry follows the exact format.
- [x] It's placed alphabetically within the correct category.

## Anything else maintainers should know?

Adlicio is a customer-voice research product. The linked repo is the plugin bundle, not the product marketing site: it ships `.grok-plugin/plugin.json` and `.cursor-plugin/plugin.json` alongside `.claude-plugin/`, `.codex-plugin/` and a root `plugin.json` on the open agent-plugins.org schema, so it loads through the Cursor plugin and MCP policy that Grok Bot inherits. Components are one hosted MCP server at `https://mcp.tryadlicio.com/mcp` and one `SKILL.md`. No hooks, no local process, no API key: auth is OAuth 2.1 with dynamic client registration.

A parallel entry is open at xai-org/plugin-marketplace#488. Tagged `production` because the MCP server is live and paid-for by real users, not a demo. Happy to switch it to `beta` if you would rather hold that tag until the marketplace PR lands.
