### PR TITLE
Add flightclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Read from each repository's own file tree on 2026-09-02. Marketplace entries are
 
 - [agentcouch](https://github.com/stoyan-stoyanov/agentcouch-plugins) by [AgentCouch](https://agentcouch.dev) — hosted messaging rooms for Grok Bot to talk with other people's agents across clients and machines. **[production]**
 - [campfiresms-grok-bot](https://github.com/campfiresms/campfiresms-grok-bot) by [CampfireSMS](https://github.com/campfiresms) — hosted SMS bridge over five MCP tools plus a safety skill, on one revocable phone-bound credential. **[beta]**
+- [flightclaw](https://github.com/jackculpan/flightclaw) by [Jack Culpan](https://github.com/jackculpan) — search Google Flights, price-track a route and book through Duffel, over one MCP server. **[beta]**
 - [GrokBotfun](https://github.com/GrokBotfun/GrokBotfun) by [GrokBotfun](https://github.com/GrokBotfun) — deploy pump.fun tokens from your agent; ships an MCP server plus a Cursor-marketplace-format plugin (not the open agent-plugins.org spec, despite the repo description). **[experimental]**
 - [imagine-mcp](https://github.com/Archive228/imagine-mcp) by [Archive228](https://github.com/Archive228) — remote MCP for xAI image, video and speech generation that returns a persistent blob URL and a per-call cost receipt. **[beta]**
 - [mcp-fetch-worker](https://github.com/jkpe/mcp-fetch-worker) by [jkpe](https://github.com/jkpe) — one `http_fetch` MCP tool behind Cloudflare Access, so a Bot reaches your self-hosted APIs on a scoped token you can revoke. **[beta]**


### PR DESCRIPTION
Adds one line to **Grok Bot plugins and MCP servers**, placed alphabetically between `campfiresms-grok-bot` and `GrokBotfun`.

```
- [flightclaw](https://github.com/jackculpan/flightclaw) by [Jack Culpan](https://github.com/jackculpan) — search Google Flights, price-track a route and book through Duffel, over one MCP server. **[beta]**
```

## Against the acceptance bar

1. **The link resolves.** https://github.com/jackculpan/flightclaw — public, active, not archived.
2. **It is about Grok Bot.** It ships `.grok-plugin/plugin.json` plus a `.mcp.json` connector, which is mechanism 1 in your extension section. It is submitted to xAI's official marketplace as [xai-org/plugin-marketplace#529](https://github.com/xai-org/plugin-marketplace/pull/529), currently open. Not Grok Build, not the Grok chat assistant.
3. **Not already listed.**
4. **Category.** It is a plugin with an MCP server, so "Grok Bot plugins and MCP servers" rather than skills.

## On the `beta` tag

The server works and lists 32 tools, but the Grok install path depends on marketplace PR #529 landing. `beta` seemed more honest than `production` until that merges. Happy to move it to `production` once it does, or to have you set it now if you read it differently.

## Coverage-table note

If it helps your `.cursor-plugin` / `.claude-plugin` rows: this repo also carries `.cursor-plugin/plugin.json` (validated against Cursor's published schemas), `.claude-plugin/plugin.json`, and `gemini-extension.json`. No `plugin.json` on the open Agent Plugins standard yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)